### PR TITLE
Global usage of sinon

### DIFF
--- a/lib/sinon-mocha.js
+++ b/lib/sinon-mocha.js
@@ -21,7 +21,7 @@ SinonMocha = {
 
   afterEach: function(){
     WrapMethod.restoreWrappedMethods();
-    sinon.wrapMethod.restore();
+    SinonMocha.sinon.wrapMethod.restore();
   }
 
 };


### PR DESCRIPTION
This little change fixes an issue where `sinon` is expected to be available as a global. I've tried to add a test for that, but the global `sinon` is a reference to `SinonMocha.sinon` and I wasn't able to stub/mock that.
