### PR TITLE
Allow enhance() to be called multiple times

### DIFF
--- a/lib/mocha-hooks.js
+++ b/lib/mocha-hooks.js
@@ -40,11 +40,10 @@ MochaHooks = {
         beforeEachHook.ctx = suite.ctx;
         beforeEachHook.timeout(suite.timeout());
         suite._beforeEach.unshift(beforeEachHook);
-
-        MochaHooks._enhanced = true;
       }
       return runSuite.apply(this, arguments);
     };
+    MochaHooks._enhanced = true;
   },
 
   /**

--- a/lib/sinon-mocha.js
+++ b/lib/sinon-mocha.js
@@ -10,9 +10,11 @@ SinonMocha = {
 
   enhance: function(sinon, mocha){
     SinonMocha.sinon = sinon;
-    Hooks.enhance(mocha);
-    Hooks.beforeEach(SinonMocha.beforeEach);
-    Hooks.afterEach(SinonMocha.afterEach);
+    if (!Hooks._enhanced) {
+      Hooks.enhance(mocha);
+      Hooks.beforeEach(SinonMocha.beforeEach);
+      Hooks.afterEach(SinonMocha.afterEach);
+    }
   },
 
   beforeEach: function(){


### PR DESCRIPTION
This way, enhance() can be called multiple times, which is useful
when it's done on top of module level.
Otherwise, wrapped method will call itself infinitely.
